### PR TITLE
chore: compatiable with react-router@7

### DIFF
--- a/packages/electron-router-dom/src/index.ts
+++ b/packages/electron-router-dom/src/index.ts
@@ -10,9 +10,11 @@ import {
   type RouteDef,
   type RouterProps,
   Router as RendererRouter,
+  getWindowId,
 } from './renderer'
 
 export type { RouteDef, RouterProps }
+export { getWindowId }
 
 import { createFileRoute } from './main/create-file'
 import { createURLRoute } from './main/create-url'

--- a/packages/electron-router-dom/src/renderer/index.tsx
+++ b/packages/electron-router-dom/src/renderer/index.tsx
@@ -3,7 +3,7 @@ import { type ComponentType, useMemo } from 'react'
 import {
   RouterProvider,
   createHashRouter,
-  createRoutesFromChildren,
+  createRoutesFromElements,
   type RouterProviderProps,
 } from 'react-router-dom'
 
@@ -18,6 +18,19 @@ export type RouterProps<T extends RouteDef> =
     }
 
 /**
+ * Helper to grep windowId from {@link location.hash}.
+ * @process renderer
+ */
+export function getWindowId(): string {
+  const selectAllSlashes = /\//g;
+
+  const rawId =
+    location.hash.split(selectAllSlashes)?.[1]?.toLowerCase() || "main";
+
+  return rawId.split("?")[0] || "main";
+}
+
+/**
  * Renders a router component based on the provided routes.
  * @process renderer
  */
@@ -25,21 +38,18 @@ export function Router<T extends RouteDef>({
   _providerProps,
   ...routes
 }: RouterProps<T>): JSX.Element {
-  const selectAllSlashes = /\//g
-
-  const rawId =
-    location.hash.split(selectAllSlashes)?.[1]?.toLowerCase() || 'main'
-
-  const windowID = rawId.split('?')[0] || 'main'
-  const transformedRoutes: RouteDef = toLowerCaseKeys(routes)
-
-  const Route = () => transformedRoutes[windowID]
-
+  const windowID = getWindowId()
   const router = useMemo(
-    () =>
-      createHashRouter(createRoutesFromChildren(Route()), {
+    () => {
+      const transformedRoutes: RouteDef = toLowerCaseKeys(routes)
+      const newRoutes = createRoutesFromElements(
+        transformedRoutes[windowID]
+      )
+
+      return createHashRouter(newRoutes, {
         basename: `/${windowID}`,
-      }),
+      })
+    },
     [windowID]
   )
 


### PR DESCRIPTION
Update 1:
In react-router@6.30.3, [createRoutesFromChildren](https://reactrouter.com/6.30.3/utils/create-routes-from-children) is an alias for [createRoutesFromElements](https://reactrouter.com/6.30.3/utils/create-routes-from-elements) .

And in react-router@7, there's no `createRoutesFromChildren` anymore. 

<img width="662" height="218" alt="image" src="https://github.com/user-attachments/assets/d17f09ae-9b3f-4bb2-90fb-454a348fdc44" />

So this PR is for future compatible.

Update 2:
- extract windowID to a reusable method, so in renderer it can do some conditional event for different window ID
- rewrite the `useMemo` for better performance